### PR TITLE
Add systemd service unit

### DIFF
--- a/redsocks.service
+++ b/redsocks.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Transparent redirector of any TCP connection to proxy using your firewall
+
+[Service]
+Type=forking
+PIDFile=/var/run/redsocks/redsocks.pid
+EnvironmentFile=/etc/conf.d/redsocks
+ExecStartPre=/usr/bin/redsocks -t -c $REDSOCKS_CONF
+ExecStart=/bin/su -s /bin/sh -c "/usr/bin/redsocks \
+  -c $REDSOCKS_CONF \
+  -p /var/run/redsocks/redsocks.pid" redsocks
+ExecStopPost=/bin/rm /var/run/redsocks/redsocks.pid
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds a basic `systemd.service` unit for redsocks.

I maintain the [redsocks package for Arch Linux](https://aur.archlinux.org/packages.php?ID=41765), which is transitioning away
from `sysvinit` to `systemd`. Although I'm new to `systemd`, it is my
understanding that one advantage of it is it allows for `rc` scripts to be
maintained upstream rather than multiple idiosyncratic scripts per distribution.

Note, I labelled it 'basic' as it also highlights a feature request for
`redsocks`: a `-u, --user` option that allows `redsocks` to drop root privileges
and switch to the given userid. This will mean `su` can be removed and simplify
the service file.
