### PR TITLE
remove need of -gnu99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ VERSION := 0.4
 
 LIBS := -levent
 CFLAGS += -g -O2
-override CFLAGS += -std=gnu99 -Wall
 
 all: $(OUT)
 

--- a/dnstc.c
+++ b/dnstc.c
@@ -122,7 +122,8 @@ static int dnstc_onenter(parser_section *section)
 	instance->config.bindaddr.sin_family = AF_INET;
 	instance->config.bindaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 
-	for (parser_entry *entry = &section->entries[0]; entry->key; entry++)
+	parser_entry *entry;
+	for (entry = &section->entries[0]; entry->key; entry++)
 		entry->addr =
 			(strcmp(entry->key, "local_ip") == 0)   ? (void*)&instance->config.bindaddr.sin_addr :
 			(strcmp(entry->key, "local_port") == 0) ? (void*)&instance->config.bindaddr.sin_port :
@@ -136,7 +137,8 @@ static int dnstc_onexit(parser_section *section)
 	dnstc_instance *instance = section->data;
 
 	section->data = NULL;
-	for (parser_entry *entry = &section->entries[0]; entry->key; entry++)
+	parser_entry *entry;
+	for (entry = &section->entries[0]; entry->key; entry++)
 		entry->addr = NULL;
 
 	instance->config.bindaddr.sin_port = htons(instance->config.bindaddr.sin_port);

--- a/parser.c
+++ b/parser.c
@@ -477,7 +477,8 @@ int parser_run(parser_context *context)
 					parser_error(context, "expected token before ``{''"); // } - I love folding
 				}
 				else {
-					for (parser_section *p = context->sections; p; p = p->next) {
+					parser_section *p;
+					for (p = context->sections; p; p = p->next) {
 						if (strcmp(p->name, section_token) == 0) {
 							section = p;
 							break;

--- a/redsocks.c
+++ b/redsocks.c
@@ -125,7 +125,8 @@ static int redsocks_onenter(parser_section *section)
 	instance->config.min_backoff_ms = 100;
 	instance->config.max_backoff_ms = 60000;
 
-	for (parser_entry *entry = &section->entries[0]; entry->key; entry++)
+	parser_entry *entry;
+	for (entry = &section->entries[0]; entry->key; entry++)
 		entry->addr =
 			(strcmp(entry->key, "local_ip") == 0)   ? (void*)&instance->config.bindaddr.sin_addr :
 			(strcmp(entry->key, "local_port") == 0) ? (void*)&instance->config.bindaddr.sin_port :
@@ -152,7 +153,8 @@ static int redsocks_onexit(parser_section *section)
 	redsocks_instance *instance = section->data;
 
 	section->data = NULL;
-	for (parser_entry *entry = &section->entries[0]; entry->key; entry++)
+	parser_entry *entry;
+	for (entry = &section->entries[0]; entry->key; entry++)
 		entry->addr = NULL;
 
 	instance->config.bindaddr.sin_port = htons(instance->config.bindaddr.sin_port);

--- a/redudp.c
+++ b/redudp.c
@@ -707,7 +707,8 @@ static int redudp_onenter(parser_section *section)
 	instance->config.udp_timeout = 30;
 	instance->config.udp_timeout_stream = 180;
 
-	for (parser_entry *entry = &section->entries[0]; entry->key; entry++)
+	parser_entry *entry;
+	for (entry = &section->entries[0]; entry->key; entry++)
 		entry->addr =
 			(strcmp(entry->key, "local_ip") == 0)   ? (void*)&instance->config.bindaddr.sin_addr :
 			(strcmp(entry->key, "local_port") == 0) ? (void*)&instance->config.bindaddr.sin_port :
@@ -730,7 +731,8 @@ static int redudp_onexit(parser_section *section)
 	redudp_instance *instance = section->data;
 
 	section->data = NULL;
-	for (parser_entry *entry = &section->entries[0]; entry->key; entry++)
+	parser_entry *entry;
+	for (entry = &section->entries[0]; entry->key; entry++)
 		entry->addr = NULL;
 
 	instance->config.bindaddr.sin_port = htons(instance->config.bindaddr.sin_port);

--- a/utils.c
+++ b/utils.c
@@ -53,7 +53,8 @@ int red_recv_udp_pkt(int fd, char *buf, size_t buflen, struct sockaddr_in *inadd
 
 	if (toaddr) {
 		memset(toaddr, 0, sizeof(*toaddr));
-		for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg); cmsg; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+		struct cmsghdr* cmsg;
+		for (cmsg = CMSG_FIRSTHDR(&msg); cmsg; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
 			if (
 				cmsg->cmsg_level == SOL_IP &&
 				cmsg->cmsg_type == IP_ORIGDSTADDR &&


### PR DESCRIPTION
This patches remove the need of "override CFLAGS" in Makefile.
Only var declaration inside the for was requiring the gnu99 flag.
