### PR TITLE
Switch from gnu99 to c99.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION := 0.4
 
 LIBS := -levent
 CFLAGS += -g -O2
-override CFLAGS += -std=gnu99 -Wall
+override CFLAGS += -std=c99 -D_XOPEN_SOURCE=600 -D_BSD_SOURCE -D_DEFAULT_SOURCE -Wall
 
 all: $(OUT)
 

--- a/list.h
+++ b/list.h
@@ -300,9 +300,9 @@ static inline void list_splice_init(struct list_head_t *list,
  * @member:	the name of the list_struct within the struct.
  */
 #define list_for_each_entry(pos, head, member)				\
-	for (pos = list_entry((head)->next, typeof(*pos), member);	\
+	for (pos = list_entry((head)->next, __typeof(*pos), member);	\
 	     &pos->member != (head); 	\
-	     pos = list_entry(pos->member.next, typeof(*pos), member))
+	     pos = list_entry(pos->member.next, __typeof(*pos), member))
 
 /**
  * list_for_each_entry_reverse - iterate backwards over list of given type.
@@ -311,9 +311,9 @@ static inline void list_splice_init(struct list_head_t *list,
  * @member:	the name of the list_struct within the struct.
  */
 #define list_for_each_entry_reverse(pos, head, member)			\
-	for (pos = list_entry((head)->prev, typeof(*pos), member);	\
+	for (pos = list_entry((head)->prev, __typeof(*pos), member);	\
 	     &pos->member != (head); 	\
-	     pos = list_entry(pos->member.prev, typeof(*pos), member))
+	     pos = list_entry(pos->member.prev, __typeof(*pos), member))
 
 /**
  * list_prepare_entry - prepare a pos entry for use in list_for_each_entry_continue
@@ -324,7 +324,7 @@ static inline void list_splice_init(struct list_head_t *list,
  * Prepares a pos entry for use as a start point in list_for_each_entry_continue.
  */
 #define list_prepare_entry(pos, head, member) \
-	((pos) ? : list_entry(head, typeof(*pos), member))
+	((pos) ? : list_entry(head, __typeof(*pos), member))
 
 /**
  * list_for_each_entry_continue - continue iteration over list of given type
@@ -336,9 +336,9 @@ static inline void list_splice_init(struct list_head_t *list,
  * the current position.
  */
 #define list_for_each_entry_continue(pos, head, member) 		\
-	for (pos = list_entry(pos->member.next, typeof(*pos), member);	\
+	for (pos = list_entry(pos->member.next, __typeof(*pos), member);	\
 	     &pos->member != (head);	\
-	     pos = list_entry(pos->member.next, typeof(*pos), member))
+	     pos = list_entry(pos->member.next, __typeof(*pos), member))
 
 /**
  * list_for_each_entry_from - iterate over list of given type from the current point
@@ -350,7 +350,7 @@ static inline void list_splice_init(struct list_head_t *list,
  */
 #define list_for_each_entry_from(pos, head, member) 			\
 	for (; &pos->member != (head);	\
-	     pos = list_entry(pos->member.next, typeof(*pos), member))
+	     pos = list_entry(pos->member.next, __typeof(*pos), member))
 
 /**
  * list_for_each_entry_safe - iterate over list of given type safe against removal of list entry
@@ -360,10 +360,10 @@ static inline void list_splice_init(struct list_head_t *list,
  * @member:	the name of the list_struct within the struct.
  */
 #define list_for_each_entry_safe(pos, n, head, member)			\
-	for (pos = list_entry((head)->next, typeof(*pos), member),	\
-		n = list_entry(pos->member.next, typeof(*pos), member);	\
+	for (pos = list_entry((head)->next, __typeof(*pos), member),	\
+		n = list_entry(pos->member.next, __typeof(*pos), member);	\
 	     &pos->member != (head); 					\
-	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
+	     pos = n, n = list_entry(n->member.next, __typeof(*n), member))
 
 /**
  * list_for_each_entry_safe_continue
@@ -376,10 +376,10 @@ static inline void list_splice_init(struct list_head_t *list,
  * safe against removal of list entry.
  */
 #define list_for_each_entry_safe_continue(pos, n, head, member) 		\
-	for (pos = list_entry(pos->member.next, typeof(*pos), member), 		\
-		n = list_entry(pos->member.next, typeof(*pos), member);		\
+	for (pos = list_entry(pos->member.next, __typeof(*pos), member), 		\
+		n = list_entry(pos->member.next, __typeof(*pos), member);		\
 	     &pos->member != (head);						\
-	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
+	     pos = n, n = list_entry(n->member.next, __typeof(*n), member))
 
 /**
  * list_for_each_entry_safe_from
@@ -392,9 +392,9 @@ static inline void list_splice_init(struct list_head_t *list,
  * removal of list entry.
  */
 #define list_for_each_entry_safe_from(pos, n, head, member) 			\
-	for (n = list_entry(pos->member.next, typeof(*pos), member);		\
+	for (n = list_entry(pos->member.next, __typeof(*pos), member);		\
 	     &pos->member != (head);						\
-	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
+	     pos = n, n = list_entry(n->member.next, __typeof(*n), member))
 
 /**
  * list_for_each_entry_safe_reverse
@@ -407,9 +407,9 @@ static inline void list_splice_init(struct list_head_t *list,
  * of list entry.
  */
 #define list_for_each_entry_safe_reverse(pos, n, head, member)		\
-	for (pos = list_entry((head)->prev, typeof(*pos), member),	\
-		n = list_entry(pos->member.prev, typeof(*pos), member);	\
+	for (pos = list_entry((head)->prev, __typeof(*pos), member),	\
+		n = list_entry(pos->member.prev, __typeof(*pos), member);	\
 	     &pos->member != (head); 					\
-	     pos = n, n = list_entry(n->member.prev, typeof(*n), member))
+	     pos = n, n = list_entry(n->member.prev, __typeof(*n), member))
 
 #endif

--- a/utils.h
+++ b/utils.h
@@ -20,6 +20,12 @@ struct sockaddr_in;
 #endif
 
 
+#ifdef __GNUC__
+#define member_type(type, member) __typeof(((type *)0)->member)
+#else
+#define member_type(type, member) const void
+#endif
+
 /**
  * container_of - cast a member of a structure out to the containing structure
  * @ptr:	the pointer to the member.
@@ -27,9 +33,11 @@ struct sockaddr_in;
  * @member:	the name of the member within the struct.
  *
  */
-#define container_of(ptr, type, member) ({			\
-	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
-	(type *)( (char *)__mptr - offsetof(type,member) );})
+#define container_of(ptr, type, member) \
+	((type *)( \
+		(char *)(member_type(type, member) *){ ptr } - offsetof(type, member) \
+	))
+
 
 #define clamp_value(value, min_val, max_val) do { \
        if (value < min_val) \


### PR DESCRIPTION
There was a bad attempt (bad meant as taking wrong approach) at removing gnu99 (along with `-Wall`, which definitely shouldn't be removed) in pull #51 and when I saw it almost month ago I just had to do things properly, i.e. perform switch from gnu99 to C99 instead. But because I was doing other things simultaneously back then I forgot to push it in the end. So here it is, finally.