### PR TITLE
add timeout parameter

### DIFF
--- a/redsocks.h
+++ b/redsocks.h
@@ -32,6 +32,7 @@ typedef struct redsocks_config_t {
 	uint16_t min_backoff_ms;
 	uint16_t max_backoff_ms; // backoff capped by 65 seconds is enough :)
 	uint16_t listenq;
+	uint16_t timeout;
 } redsocks_config;
 
 struct tracked_event {
@@ -61,6 +62,7 @@ typedef struct redsocks_client_t {
 	unsigned short      relay_evshut;
 	time_t              first_event;
 	time_t              last_event;
+    uint16_t            timeout;
 } redsocks_client;
 
 


### PR DESCRIPTION
I propose to add a timeout parameter to redsocks.
usage Scenario:
When using redsocks to also redirect naming resolution (DNS) via forward of udp port 53 to the built in DNS responder (with forcing redirect to tcp), the resolver get's a bit confused when the remote host is unreachable as it is able to connect but times out on send/receive. This leads to long timeouts when using DNS resolution (with no chance to lower them by resolver settings).
With an additional timeout option we can easily configure a second redsocks section in the config file using an own port only for DNS forwarding and applying a timeout value there.
Example:
iptables -t nat -I REDSOCKS -d 0.0.0.0/0 -p tcp --dport 53 -j REDIRECT --to-ports 12346
and in the config file (beside the normal forwarding stuff):
redsocks {
        local_ip = 127.0.0.1;
        local_port = 12346;
        ip=...
        port=....
        ....
         timeout = 1;
}
