### PR TITLE
Use CC variable instead of hardcoded gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ gen/.build:
 base.c: $(CONF)
 
 $(DEPS): $(SRCS)
-	gcc -MM $(SRCS) 2>/dev/null >$(DEPS) || \
+	$(CC) -MM $(SRCS) 2>/dev/null >$(DEPS) || \
 	( \
 		for I in $(wildcard *.h); do \
 			export $${I//[-.]/_}_DEPS="`sed '/^\#[ \t]*include \?"\(.*\)".*/!d;s//\1/' $$I`"; \


### PR DESCRIPTION
So it should work with clang too on FreeBSD.
It still does not work because of #34, so I was unable to test it.