### PR TITLE
Fixes for non-linux platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(CONF):
 	Linux*) \
 		echo "#define USE_IPTABLES" >$(CONF) \
 		;; \
-	OpenBSD) \
+	OpenBSD|GNU/kFreeBSD) \
 		echo "#define USE_PF" >$(CONF) \
 		;; \
 	*) \

--- a/base.c
+++ b/base.c
@@ -251,9 +251,11 @@ int apply_tcp_keepalive(int fd)
 {
 	struct { int level, option, value; } opt[] = {
 		{ SOL_SOCKET, SO_KEEPALIVE, 1 },
+#if defined(TCP_KEEPIDLE) && defined(TCP_KEEPCNT) && defined(TCP_KEEPINTVL)
 		{ IPPROTO_TCP, TCP_KEEPIDLE, instance.tcp_keepalive_time },
 		{ IPPROTO_TCP, TCP_KEEPCNT, instance.tcp_keepalive_probes },
 		{ IPPROTO_TCP, TCP_KEEPINTVL, instance.tcp_keepalive_intvl },
+#endif
 	};
 	for (int i = 0; i < SIZEOF_ARRAY(opt); ++i) {
 		if (opt[i].value) {

--- a/list.h
+++ b/list.h
@@ -31,7 +31,7 @@ typedef struct list_head_t {
 
 #define LIST_HEAD_INIT(name) { &(name), &(name) }
 
-#define LIST_HEAD(name) \
+#define RED_LIST_HEAD(name) \
 	struct list_head_t name = LIST_HEAD_INIT(name)
 
 static inline void INIT_LIST_HEAD(struct list_head_t *list)

--- a/main.c
+++ b/main.c
@@ -85,6 +85,9 @@ int main(int argc, char **argv)
 				       "  Headers: %8x\n"
 				       "  Runtime: %8x\n", LIBEVENT_VERSION_NUMBER, event_get_version_number());
 			}
+#ifdef USE_SPLICE
+			printf("Built with splice(2) support\n");
+#endif
 			return EXIT_SUCCESS;
 		default:
 			printf(

--- a/main.h
+++ b/main.h
@@ -1,6 +1,7 @@
 #ifndef MAIN_H_TUE_JAN_23_15_38_25_2007
 #define MAIN_H_TUE_JAN_23_15_38_25_2007
 
+#include <fcntl.h>
 #include "parser.h"
 
 struct event_base;
@@ -15,6 +16,9 @@ typedef struct app_subsys_t {
 #define FOREACH(ptr, array)      for (ptr = array; ptr < array + SIZEOF_ARRAY(array); ptr++)
 #define FOREACH_REV(ptr, array)  for (ptr = array + SIZEOF_ARRAY(array) - 1; ptr >= array; ptr--)
 
+#ifdef SPLICE_F_MOVE
+# define USE_SPLICE
+#endif
 
 /* vim:set tabstop=4 softtabstop=4 shiftwidth=4: */
 /* vim:set foldmethod=marker foldlevel=32 foldmarker={,}: */

--- a/redsocks.c
+++ b/redsocks.c
@@ -94,6 +94,11 @@ static bool is_splice_good()
 		return false;
 	}
 
+	/* splice(2) is Linux-specific */
+	if (strcmp(u.sysname, "Linux") != 0) {
+		return false;
+	}
+
 	unsigned long int v[4] = { 0, 0, 0, 0 };
 	char *rel = u.release;
 	for (int i = 0; i < SIZEOF_ARRAY(v); ++i) {
@@ -1410,6 +1415,11 @@ static int redsocks_init_instance(redsocks_instance *instance)
 	if (error) {
 		log_errno(LOG_ERR, "event_add");
 		goto fail;
+	}
+
+	if (instance->config.use_splice && !is_splice_good()) {
+		log_error(LOG_WARNING, "splice(2) support requested but unavailable; ignoring");
+		instance->config.use_splice = false;
 	}
 
 	if (instance->relay_ss->instance_init)

--- a/redsocks.c
+++ b/redsocks.c
@@ -27,7 +27,6 @@
 #include <time.h>
 #include <errno.h>
 #include <assert.h>
-#include <fcntl.h>
 #include <event.h>
 #include "list.h"
 #include "parser.h"
@@ -40,10 +39,6 @@
 
 
 #define REDSOCKS_RELAY_HALFBUFF  4096
-
-#ifdef SPLICE_F_MOVE
-# define USE_SPLICE
-#endif
 
 enum pump_state_t {
 	pump_active = -1,

--- a/redsocks.conf.example
+++ b/redsocks.conf.example
@@ -32,7 +32,7 @@ base {
 	/* possible `redirector' values are:
 	 *   iptables   - for Linux
 	 *   ipf        - for FreeBSD
-	 *   pf         - for OpenBSD
+	 *   pf         - for OpenBSD and Debian GNU/kFreeBSD
 	 *   generic    - some generic redirector that MAY work
 	 */
 	redirector = iptables;


### PR DESCRIPTION
Hi,

These changes make redsocks 0.5 build on non-linux platforms (tested on Debian GNU/KFreeBSD) again. The most important change is making `splice(2)` support optional at build- and run-time, as well as using the `TCP_KEEPIDLE` socket options et. al only when available.

Regards,
Apollon