### PR TITLE
Make sure to run `accept_enable` when handling `accept_backoff_ev`

### DIFF
--- a/redsocks.c
+++ b/redsocks.c
@@ -1078,11 +1078,10 @@ static void conn_pressure_lowered()
 
 static void redsocks_accept_backoff(int fd, short what, void *_null)
 {
-	if (conn_pressure_ongoing()) {
+	accept_enable(); // `accept_backoff_ev` is not pending now
+
+	if (conn_pressure_ongoing())
 		conn_pressure(); // rearm timeout
-	} else {
-		accept_enable(); // `accept_backoff_ev` is not pending now
-	}
 }
 
 void redsocks_close_internal(int fd, const char* file, int line, const char *func)


### PR DESCRIPTION
This fixes issue #99.

There's a situation where the connection pressure is solved but redsocks doesn't resume listening to new connections.

1. `redsocks_conn_max` is hit, `conn_pressure` runs.
2. There are no long-idle connections, so `conn_pressure` adds the `accept_backoff_ev` event and disables all listeners.
3. Some time passes.
4. `accept_backoff_ev` gets triggered and `redsocks_accept_backoff` gets called.
5. `conn_pressure_ongoing() == true`, so `conn_pressure` runs.
6. This time there's a connection that's more than 7440s old. `conn_pressure` drops it and returns.
7. Now `conn_pressure_ongoing() == false`, but `accept_enable` isn't called because the conditional was evaluated before running `conn_pressure`.
8. `redsocks_accept_backoff` returns, so `accept_backoff_ev` is not pending anymore and `accept_enable` will never be called.