### PR TITLE
Update Makefile to support cross compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ tags: *.c *.h
 	ctags -R
 
 $(CONF):
-	@case `uname` in \
-	Linux*) \
+	@case `$(CC) -dumpmachine` in \
+	*linux*) \
 		echo "#define USE_IPTABLES" >$(CONF) \
 		;; \
-	OpenBSD) \
+	*openbsd*) \
 		echo "#define USE_PF" >$(CONF) \
 		;; \
 	*) \
@@ -66,7 +66,7 @@ gen/.build:
 base.c: $(CONF)
 
 $(DEPS): $(SRCS)
-	gcc -MM $(SRCS) 2>/dev/null >$(DEPS) || \
+	$(CC) -MM $(SRCS) 2>/dev/null >$(DEPS) || \
 	( \
 		for I in $(wildcard *.h); do \
 			export $${I//[-.]/_}_DEPS="`sed '/^\#[ \t]*include \?"\(.*\)".*/!d;s//\1/' $$I`"; \


### PR DESCRIPTION
Tested on lede (fork of OpenWRT) and works though lede doesn't like the libevent_core LIB and only works if I change it to libevent but this should probably be a lede patch and not a generic fix.

I have not tested this on openbsd but from I can find `gcc -dumpmachine' should return something with openbsd.