### PR TITLE
Fix redsocks_evbuffer_readline with libevent 2.1

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -117,7 +117,7 @@ int redsocks_gettimeofday(struct timeval *tv)
 
 char *redsocks_evbuffer_readline(struct evbuffer *buf)
 {
-#if _EVENT_NUMERIC_VERSION >= 0x02000000
+#if LIBEVENT_VERSION_NUMBER >= 0x02000000
 	return evbuffer_readln(buf, NULL, EVBUFFER_EOL_CRLF);
 #else
 	return evbuffer_readline(buf);


### PR DESCRIPTION
_EVENT_NUMERIC_VERSION was renamed to EVENT__NUMERIC_VERSION in libevent
2.1. As a result, redsocks_evbuffer_readline would end up using
evbuffer_readline(buf), which causes client connections to hang
indefinitely.

Switch the check to using LIBEVENT_VERSION_NUMBER instead.
LIBEVENT_VERSION_NUMBER has been around since libevent 2.0.3 and
redsocks is already using it in other parts of the code.

Fixes #107, #122.