### PR TITLE
consistent use of quotes for login and password

### DIFF
--- a/redsocks.conf.example
+++ b/redsocks.conf.example
@@ -124,8 +124,8 @@ redudp {
 	// `ip' and `port' of socks5 proxy server.
 	ip = 10.0.0.1;
 	port = 1080;
-	login = username;
-	password = pazzw0rd;
+	login = "username";
+	password = "pazzw0rd";
 
 	// redsocks knows about two options while redirecting UDP packets at
 	// linux: TPROXY and REDIRECT.  TPROXY requires more complex routing


### PR DESCRIPTION
redsocks uses quotes for login and password but redudp uses no quotes for login and password.

Assuming this inconsistency is a bug.
